### PR TITLE
Fix dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='robinpeder@gmail.com',
     license='MIT license',
     install_requires=[
-        'pytest>=2.6.0',
+        'pytest>=2.6.0, <=3.2.5',
     ],
     entry_points={
         'pytest11': [


### PR DESCRIPTION
_memoizedcall is removed from PyCollector in pytest above 3.2.5